### PR TITLE
WASM breaks in Node v19

### DIFF
--- a/src/abigen/wasm/wasm_exec_node.js
+++ b/src/abigen/wasm/wasm_exec_node.js
@@ -14,10 +14,12 @@ globalThis.performance = {
   },
 };
 
-globalThis.crypto = {
-  getRandomValues(b) {
-    crypto.randomFillSync(b);
+Object.defineProperty(globalThis, "crypto", {
+  value: {
+    getRandomValues(b) {
+      crypto.randomFillSync(b);
+    },
   },
-};
+});
 
 require("./wasm_exec");


### PR DESCRIPTION
Fixed Cannot set property crypto of #<Object> which has only a getter for Node v19

Related: https://github.com/golang/go/issues/56860