### PR TITLE
Add compatibility with Hardhat 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "hardhat": "^2.10.0"
+        "hardhat": "^2.10.0 || ^3.0.0"
       }
     },
     "node_modules/@bytecodealliance/preview2-shim": {
@@ -749,28 +749,28 @@
       "license": "MIT"
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.11.0.tgz",
-      "integrity": "sha512-36WERf8ldvyHR6UAbcYsa+vpbW7tCrJGBwF4gXSsb8+STj1n66Hz85Y/O7B9+8AauX3PhglvV5dKl91tk43mWw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.11.3.tgz",
+      "integrity": "sha512-kqILRkAd455Sd6v8mfP3C1/0tCOynJWY+Ir+k/9Boocu2kObCrsFgG+ZWB7fSBVdd9cPVSNrnhWS+V+PEo637g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.11.0",
-        "@nomicfoundation/edr-darwin-x64": "0.11.0",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.11.0",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.11.0",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.11.0",
-        "@nomicfoundation/edr-linux-x64-musl": "0.11.0",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.11.0"
+        "@nomicfoundation/edr-darwin-arm64": "0.11.3",
+        "@nomicfoundation/edr-darwin-x64": "0.11.3",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.11.3",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.11.3",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.11.3",
+        "@nomicfoundation/edr-linux-x64-musl": "0.11.3",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.11.3"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.11.0.tgz",
-      "integrity": "sha512-aYTVdcSs27XG7ayTzvZ4Yn9z/ABSaUwicrtrYK2NR8IH0ik4N4bWzo/qH8rax6rewVLbHUkGyGYnsy5ZN4iiMw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.11.3.tgz",
+      "integrity": "sha512-w0tksbdtSxz9nuzHKsfx4c2mwaD0+l5qKL2R290QdnN9gi9AV62p9DHkOgfBdyg6/a6ZlnQqnISi7C9avk/6VA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.11.0.tgz",
-      "integrity": "sha512-RxX7UYgvJrfcyT/uHUn44Nsy1XaoW+Q1khKMdHKxeW7BrgIi+Lz+siz3bX5vhSoAnKilDPhIVLrnC8zxQhjR2A==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.11.3.tgz",
+      "integrity": "sha512-QR4jAFrPbOcrO7O2z2ESg+eUeIZPe2bPIlQYgiJ04ltbSGW27FblOzdd5+S3RoOD/dsZGKAvvy6dadBEl0NgoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.11.0.tgz",
-      "integrity": "sha512-J0j+rs0s11FuSipt/ymqrFmpJ7c0FSz1/+FohCIlUXDxFv//+1R/8lkGPjEYFmy8DPpk/iO8mcpqHTGckREbqA==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.11.3.tgz",
+      "integrity": "sha512-Ktjv89RZZiUmOFPspuSBVJ61mBZQ2+HuLmV67InNlh9TSUec/iDjGIwAn59dx0bF/LOSrM7qg5od3KKac4LJDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.11.0.tgz",
-      "integrity": "sha512-4r32zkGMN7WT/CMEuW0VjbuEdIeCskHNDMW4SSgQSJOE/N9L1KSLJCSsAbPD3aYE+e4WRDTyOwmuLjeUTcLZKQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.11.3.tgz",
+      "integrity": "sha512-B3sLJx1rL2E9pfdD4mApiwOZSrX0a/KQSBWdlq1uAhFKqkl00yZaY4LejgZndsJAa4iKGQJlGnw4HCGeVt0+jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.11.0.tgz",
-      "integrity": "sha512-SmdncQHLYtVNWLIMyGaY6LpAfamzTDe3fxjkirmJv3CWR5tcEyC6LMui/GsIVnJzXeNJBXAzwl8hTUAxHTM6kQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.11.3.tgz",
+      "integrity": "sha512-D/4cFKDXH6UYyKPu6J3Y8TzW11UzeQI0+wS9QcJzjlrrfKj0ENW7g9VihD1O2FvXkdkTjcCZYb6ai8MMTCsaVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.11.0.tgz",
-      "integrity": "sha512-w6hUqpn/trwiH6SRuRGysj37LsQVCX5XDCA3Xi81sbOaLhbHrNvK9TXWyZmcuzbdTKQQW6VNywcSxDdOiChcJg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.11.3.tgz",
+      "integrity": "sha512-ergXuIb4nIvmf+TqyiDX5tsE49311DrBky6+jNLgsGDTBaN1GS3OFwFS8I6Ri/GGn6xOaT8sKu3q7/m+WdlFzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -828,9 +828,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.11.0.tgz",
-      "integrity": "sha512-BLmULjRKoH9BsX+c4Na2ypV7NGeJ+M6Zpqj/faPOwleVscDdSr/IhriyPaXCe8dyfwbge7lWsbekiADtPSnB2Q==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.11.3.tgz",
+      "integrity": "sha512-snvEf+WB3OV0wj2A7kQ+ZQqBquMcrozSLXcdnMdEl7Tmn+KDCbmFKBt3Tk0X3qOU4RKQpLPnTxdM07TJNVtung==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1143,27 +1143,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
-      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.3.20",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1180,6 +1163,7 @@
       "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1831,11 +1815,14 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -1886,9 +1873,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -2045,19 +2032,17 @@
       "license": "ISC"
     },
     "node_modules/hardhat": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.24.0.tgz",
-      "integrity": "sha512-wDkD5GPmttYv21MR7tGDkyQ22tO2V86OEV8pA7NcXWYUpibe8XZ2EanXCeRHO61vwEx0f7/M+NqrhJwasaNMJg==",
+      "version": "2.26.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.26.3.tgz",
+      "integrity": "sha512-gBfjbxCCEaRgMCRgTpjo1CEoJwqNPhyGMMVHYZJxoQ3LLftp2erSVf8ZF6hTQC0r2wst4NcqNmLWqMnHg1quTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
-        "@nomicfoundation/edr": "^0.11.0",
+        "@nomicfoundation/edr": "^0.11.3",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
-        "@types/bn.js": "^5.1.0",
-        "@types/lru-cache": "^5.1.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
@@ -2227,6 +2212,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/hardhat/node_modules/supports-color": {
@@ -2987,9 +2982,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3031,19 +3026,6 @@
       },
       "peerDependencies": {
         "prettier": ">=3.0.0"
-      }
-    },
-    "node_modules/prettier-plugin-solidity/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/randombytes": {
@@ -3153,13 +3135,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -3396,14 +3381,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3571,7 +3556,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "4.17.21"
   },
   "peerDependencies": {
-    "hardhat": "^2.10.0"
+    "hardhat": "^2.10.0 || ^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.20",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { isAbsolute } from "path";
 
 import { ConfigExtender } from "hardhat/types";
-import { NomicLabsHardhatPluginError } from "hardhat/plugins";
+import { HardhatPluginError } from "hardhat/plugins";
 
 import { pluginName } from "./constants";
 import { DlGoBindConfig } from "./types";
@@ -23,11 +23,11 @@ export const getDefaultGoBindConfig: ConfigExtender = (resolvedConfig, config) =
   }
 
   if (!areRelativePaths(config.gobind.onlyFiles)) {
-    throw new NomicLabsHardhatPluginError(pluginName, "config.gobind.onlyFiles must only include relative paths");
+    throw new HardhatPluginError(pluginName, "config.gobind.onlyFiles must only include relative paths");
   }
 
   if (!areRelativePaths(config.gobind.skipFiles)) {
-    throw new NomicLabsHardhatPluginError(pluginName, "config.gobind.skipFiles must only include relative paths");
+    throw new HardhatPluginError(pluginName, "config.gobind.skipFiles must only include relative paths");
   }
 
   const { cloneDeep } = require("lodash");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,14 @@
-const Generator = require("./abigen/generator");
-
 import { extendConfig, task, types } from "hardhat/config";
-import { NomicLabsHardhatPluginError } from "hardhat/plugins";
-
+import { HardhatPluginError } from "hardhat/plugins";
 import { TASK_CLEAN, TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
-
 import { ActionType } from "hardhat/types";
 
 import "./type-extensions";
 
 import { getDefaultGoBindConfig } from "./config";
 import { TASK_GOBIND, pluginName } from "./constants";
+
+const Generator = require("./abigen/generator");
 
 interface BindingArgs {
   outdir?: string;
@@ -20,12 +18,13 @@ interface BindingArgs {
   _abigenPath?: string;
 }
 
+// Aplicar configuração padrão
 extendConfig(getDefaultGoBindConfig);
 
 const gobind: ActionType<BindingArgs> = async ({ outdir, deployable, noCompile, v2, _abigenPath }, hre) => {
-  hre.config.gobind.outdir = outdir === undefined ? hre.config.gobind.outdir : outdir;
-  hre.config.gobind.deployable = !deployable ? hre.config.gobind.deployable : deployable;
-  hre.config.gobind.abigenVersion = !v2 ? hre.config.gobind.abigenVersion : "v2";
+  (hre.config as any).gobind.outdir = outdir === undefined ? (hre.config as any).gobind.outdir : outdir;
+  (hre.config as any).gobind.deployable = !deployable ? (hre.config as any).gobind.deployable : deployable;
+  (hre.config as any).gobind.abigenVersion = !v2 ? (hre.config as any).gobind.abigenVersion : "v2";
 
   if (!noCompile) {
     await hre.run(TASK_COMPILE, { generateBind: false, v2: v2, _abigenPath: _abigenPath });
@@ -36,7 +35,7 @@ const gobind: ActionType<BindingArgs> = async ({ outdir, deployable, noCompile, 
 
     console.log(`\nGenerated bindings for ${contracts.length} contracts`);
   } catch (e: any) {
-    throw new NomicLabsHardhatPluginError(pluginName, e.message);
+    throw new HardhatPluginError(pluginName, e.message);
   }
 };
 
@@ -63,7 +62,7 @@ task(TASK_COMPILE)
     ) => {
       await runSuper();
 
-      if (config.gobind.runOnCompile || generateBindings) {
+      if ((config as any).gobind.runOnCompile || generateBindings) {
         await run(TASK_GOBIND, { noCompile: true, v2: v2, _abigenPath: _abigenPath });
       }
     },
@@ -75,7 +74,7 @@ task(TASK_CLEAN, "Clears the cache and deletes all artifacts").setAction(
       try {
         await new Generator(hre).clean();
       } catch (e: any) {
-        throw new NomicLabsHardhatPluginError(pluginName, e.message);
+        throw new HardhatPluginError(pluginName, e.message);
       }
 
     await runSuper();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Update peer dependencies to support Hardhat v3.x alongside v2.x, replace deprecated NomicLabsHardhatPluginError with HardhatPluginError, add moduleResolution to TypeScript config, and update dependencies to latest versions.

- [ ] Since this PR suggests a **bug fix**, the tests have been added.
- [ ] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [ ] This PR is just a **minor change**, like a typo fix.

---
